### PR TITLE
fix: remove duplicate bcrypt dependency

### DIFF
--- a/LocalMind-Backend/package.json
+++ b/LocalMind-Backend/package.json
@@ -55,7 +55,6 @@
     "@types/mongoose": "^5.11.97",
     "@types/morgan": "^1.9.10",
     "argon2": "^0.44.0",
-    "bcrypt": "^5.1.1",
     "axios": "^1.12.2",
     "bcrypt": "^6.0.0",
     "chalk": "^5.6.2",


### PR DESCRIPTION
Fixes #63
This PR removes the duplicate `bcrypt` dependency from `LocalMind-Backend/package.json` to prevent version conflicts and keep dependencies clean.

### Changes
- Removed duplicate `bcrypt` entry
- Ensured only a single consistent version is used