### PR TITLE
fix: correct typo in mongoose connection function name

### DIFF
--- a/LocalMind-Backend/src/config/mongoose.connection.ts
+++ b/LocalMind-Backend/src/config/mongoose.connection.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import { env } from '../constant/env.constant'
 
-const mongooseConection = () => {
+const mongooseConnection = () => {
   mongoose
     .connect(env.DB_CONNECTION_STRING, {
       serverSelectionTimeoutMS: 5000,
@@ -11,8 +11,8 @@ const mongooseConection = () => {
     })
     .catch((err) => {
       console.log(err)
-      setTimeout(mongooseConection, 5000)
+      setTimeout(mongooseConnection, 5000)
     })
 }
 
-export default mongooseConection
+export default mongooseConnection

--- a/LocalMind-Backend/src/server.ts
+++ b/LocalMind-Backend/src/server.ts
@@ -1,5 +1,5 @@
 import { env } from './constant/env.constant'
-import mongooseConection from './config/mongoose.connection'
+import mongooseConnection from './config/mongoose.connection'
 import app from './routes/app'
 
 const PORT = Number(env.PORT) || 3000
@@ -14,7 +14,7 @@ app.get('/', async (_req, res) => {
 app.listen(PORT, HOST, () => {
   console.log(`🚀 Server running in ${APP_ENV} mode at http://${HOST}:${PORT}`)
 
-  mongooseConection()
+  mongooseConnection()
 
   if (APP_ENV === 'development') {
     console.log('🔒 Local-only access enabled (via localhost)')


### PR DESCRIPTION
Fixed typo: 'mongooseConection' → 'mongooseConnection'

The function name had a missing 'n' which could cause confusion and doesn't follow standard naming conventions.

Files changed:
- LocalMind-Backend/src/config/mongoose.connection.ts
- LocalMind-Backend/src/server.ts