### PR TITLE
Fix README markdown rendering issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ EmailService (Main Orchestrator)
 ┃
 ┗━━ 📊 Observability
     ┗━━ 📝 Logger ............. [Structured JSON Logging]
+```
+
   <br/><br/>
   <h1><b>LocalMind — AI Without Limits</b></h1>
   <p>


### PR DESCRIPTION
### 📌 Summary
This PR fixes a Markdown formatting issue in `README.md` where an unclosed fenced code block caused the remaining content to render as raw code instead of formatted Markdown.

---

### ❌ Problem
- A fenced code block in the **Architecture** section was missing a closing triple backtick
- This caused all following content to appear as plain text
- The README became difficult to read for users and contributors

---

### ✅ Solution
- Added the missing closing code fence (` ``` `)
- Restored proper Markdown and HTML rendering
- No functional or behavioral changes to the application

---

### 🧪 Testing
- Verified README renders correctly on GitHub
- Checked headings, links, badges, and sections after the fix
- Confirmed no regressions

---

### 📂 Files Changed
- `README.md`

---

### 🔖 Type of Change
- Documentation bug fix