### PR TITLE
feat: Add admin dashboard foundation with user statistics

### DIFF
--- a/LocalMind-Backend/src/api/v1/user/user.constant.ts
+++ b/LocalMind-Backend/src/api/v1/user/user.constant.ts
@@ -87,6 +87,11 @@ enum UserConstant {
 
   API_KEY_REVEALED = 'API key revealed successfully',
   API_KEY_REVEAL_FAILED = 'Failed to reveal API key',
+
+  // ✅ ADMIN OPERATIONS
+  ADMIN_STATS_SUCCESS = 'Admin statistics fetched successfully',
+  ADMIN_STATS_FAILED = 'Failed to fetch admin statistics',
+  ADMIN_ONLY = 'Access denied. Admin privileges required',
 }
 
 export default UserConstant

--- a/LocalMind-Backend/src/api/v1/user/user.controller.ts
+++ b/LocalMind-Backend/src/api/v1/user/user.controller.ts
@@ -15,6 +15,7 @@ class UserController {
     this.profile = this.profile.bind(this)
     this.apiEndPointCreater = this.apiEndPointCreater.bind(this)
     this.getApiKey = this.getApiKey.bind(this)
+    this.getAdminStats = this.getAdminStats.bind(this)
   }
 
   private setHeaderToken(res: Response, token: string): void {
@@ -156,6 +157,16 @@ class UserController {
       SendResponse.success(res, UserConstant.API_KEY_FETCHED, { apiKey: maskedKey }, 200)
     } catch (err: any) {
       SendResponse.error(res, err.message || UserConstant.SERVER_ERROR, 500, err)
+    }
+  }
+
+  async getAdminStats(req: Request, res: Response): Promise<void> {
+    try {
+      const stats = await userService.getAdminStats()
+
+      SendResponse.success(res, UserConstant.ADMIN_STATS_SUCCESS, stats, StatusConstant.OK)
+    } catch (err: any) {
+      SendResponse.error(res, err.message || UserConstant.ADMIN_STATS_FAILED, StatusConstant.INTERNAL_SERVER_ERROR, err)
     }
   }
 }

--- a/LocalMind-Backend/src/api/v1/user/user.middleware.ts
+++ b/LocalMind-Backend/src/api/v1/user/user.middleware.ts
@@ -24,6 +24,31 @@ class UserMiddleware {
       SendResponse.error(res, err.message || UserConstant.SERVER_ERROR, 500)
     }
   }
+
+  async adminMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const token = req.headers.authorization?.split(' ')[1] || req.cookies?.token
+
+      if (!token) {
+        throw new Error(UserConstant.TOKEN_MISSING)
+      }
+
+      const decodedData: Partial<IUser> | null = UserUtils.verifyToken(token)
+
+      if (!decodedData) {
+        throw new Error(UserConstant.INVALID_TOKEN)
+      }
+
+      if (decodedData.role !== 'admin') {
+        throw new Error(UserConstant.ADMIN_ONLY)
+      }
+
+      req.user = decodedData
+      return next()
+    } catch (err: any) {
+      SendResponse.error(res, err.message || UserConstant.SERVER_ERROR, err.message === UserConstant.ADMIN_ONLY ? 403 : 500)
+    }
+  }
 }
 
 export default new UserMiddleware()

--- a/LocalMind-Backend/src/api/v1/user/user.routes.ts
+++ b/LocalMind-Backend/src/api/v1/user/user.routes.ts
@@ -12,6 +12,9 @@ router.get('/v1/auth/apiKey/generate', userMiddleware.middleware, userController
 router.get('/v1/auth/profile', userMiddleware.middleware, userController.profile)
 router.get('/v1/auth/apiKey', userMiddleware.middleware, userController.getApiKey)
 
+// Admin routes
+router.get('/v1/admin/stats', userMiddleware.adminMiddleware, userController.getAdminStats)
+
 // router.post("v1/user/apikey/reveal",   userMiddleware.middleware, UserController.revealApiKey);
 
 export { router as userRoutes }

--- a/LocalMind-Backend/src/api/v1/user/user.service.ts
+++ b/LocalMind-Backend/src/api/v1/user/user.service.ts
@@ -50,5 +50,29 @@ class userService {
       throw new Error(err.message)
     }
   }
+
+  async getAdminStats() {
+    try {
+      const totalUsers = await User.countDocuments()
+      const adminUsers = await User.countDocuments({ role: 'admin' })
+      const regularUsers = await User.countDocuments({ role: 'user' })
+      const creatorUsers = await User.countDocuments({ role: 'creator' })
+
+      const recentUsers = await User.find()
+        .select('firstName email role createdAt')
+        .sort({ createdAt: -1 })
+        .limit(10)
+
+      return {
+        totalUsers,
+        adminUsers,
+        regularUsers,
+        creatorUsers,
+        recentUsers,
+      }
+    } catch (err: any) {
+      throw new Error(err.message)
+    }
+  }
 }
 export default new userService()

--- a/LocalMind-Frontend/src/app/routes/AdminRoutes.tsx
+++ b/LocalMind-Frontend/src/app/routes/AdminRoutes.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Route, Routes } from 'react-router-dom'
+import AdminDashboard from '../../features/Admin/V1/Component/Pages/AdminDashboard'
+
+const AdminRoutes: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/admin/dashboard" element={<AdminDashboard />} />
+    </Routes>
+  )
+}
+
+export default AdminRoutes

--- a/LocalMind-Frontend/src/app/routes/AppRoutes.tsx
+++ b/LocalMind-Frontend/src/app/routes/AppRoutes.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import HomePage from '../../features/Dashboard/V1/Component/Pages/HomePage'
 import LoginPage from '../../shared/component/v1/LoginPage'
+import AdminDashboard from '../../features/Admin/V1/Component/Pages/AdminDashboard'
 
 const AppRoutes: React.FC = () => {
   return (
@@ -17,6 +18,9 @@ const AppRoutes: React.FC = () => {
 
       {/* Forgot Password Page - TODO: Create ForgotPasswordPage component */}
       <Route path="/forgot-password" element={<LoginPage />} />
+
+      {/* Admin Dashboard */}
+      <Route path="/admin/dashboard" element={<AdminDashboard />} />
 
       {/* Chat Page */}
     </Routes>

--- a/LocalMind-Frontend/src/features/Admin/V1/Component/Pages/AdminDashboard.tsx
+++ b/LocalMind-Frontend/src/features/Admin/V1/Component/Pages/AdminDashboard.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+interface AdminStats {
+  totalUsers: number
+  adminUsers: number
+  regularUsers: number
+  creatorUsers: number
+  recentUsers: Array<{
+    _id: string
+    firstName: string
+    email: string
+    role: string
+    createdAt: string
+  }>
+}
+
+const AdminDashboard: React.FC = () => {
+  const navigate = useNavigate()
+  const [stats, setStats] = useState<AdminStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchAdminStats()
+  }, [])
+
+  const fetchAdminStats = async () => {
+    try {
+      setLoading(true)
+      const token =
+        localStorage.getItem('token') || document.cookie.split('token=')[1]?.split(';')[0]
+
+      if (!token) {
+        setError('Authentication required')
+        navigate('/login')
+        return
+      }
+
+      const response = await fetch('http://localhost:8000/api/v1/admin/stats', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        if (response.status === 403) {
+          setError('Access denied. Admin privileges required.')
+        } else if (response.status === 401) {
+          setError('Authentication failed')
+          navigate('/login')
+        } else {
+          setError('Failed to fetch admin statistics')
+        }
+        return
+      }
+
+      const data = await response.json()
+      setStats(data.data)
+      setError(null)
+    } catch (err) {
+      setError('An error occurred while fetching statistics')
+      console.error('Error fetching admin stats:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#292828] flex items-center justify-center">
+        <div className="text-white text-xl">Loading...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-[#292828] flex items-center justify-center">
+        <div className="bg-red-500 text-white p-6 rounded-lg max-w-md">
+          <h2 className="text-xl font-bold mb-2">Error</h2>
+          <p>{error}</p>
+          <button
+            onClick={() => navigate('/login')}
+            className="mt-4 bg-white text-red-500 px-4 py-2 rounded hover:bg-gray-100"
+          >
+            Go to Login
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[#292828] p-4 md:p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">Admin Dashboard</h1>
+          <p className="text-gray-400">System usage and user statistics</p>
+        </div>
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+          <div className="bg-[#181818] rounded-xl p-6 shadow-lg border border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-gray-400 text-sm mb-1">Total Users</p>
+                <p className="text-3xl font-bold text-white">{stats?.totalUsers || 0}</p>
+              </div>
+              <div className="bg-blue-500 bg-opacity-20 p-3 rounded-lg">
+                <svg
+                  className="w-8 h-8 text-blue-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#181818] rounded-xl p-6 shadow-lg border border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-gray-400 text-sm mb-1">Admin Users</p>
+                <p className="text-3xl font-bold text-white">{stats?.adminUsers || 0}</p>
+              </div>
+              <div className="bg-purple-500 bg-opacity-20 p-3 rounded-lg">
+                <svg
+                  className="w-8 h-8 text-purple-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#181818] rounded-xl p-6 shadow-lg border border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-gray-400 text-sm mb-1">Regular Users</p>
+                <p className="text-3xl font-bold text-white">{stats?.regularUsers || 0}</p>
+              </div>
+              <div className="bg-green-500 bg-opacity-20 p-3 rounded-lg">
+                <svg
+                  className="w-8 h-8 text-green-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#181818] rounded-xl p-6 shadow-lg border border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-gray-400 text-sm mb-1">Creator Users</p>
+                <p className="text-3xl font-bold text-white">{stats?.creatorUsers || 0}</p>
+              </div>
+              <div className="bg-yellow-500 bg-opacity-20 p-3 rounded-lg">
+                <svg
+                  className="w-8 h-8 text-yellow-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Recent Users Table */}
+        <div className="bg-[#181818] rounded-xl shadow-lg border border-gray-700 overflow-hidden">
+          <div className="p-6 border-b border-gray-700">
+            <h2 className="text-xl font-bold text-white">Recent Users</h2>
+            <p className="text-gray-400 text-sm mt-1">Last 10 registered users</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-[#0f0f0f]">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Name
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Email
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Role
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                    Joined
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700">
+                {stats?.recentUsers && stats.recentUsers.length > 0 ? (
+                  stats.recentUsers.map(user => (
+                    <tr key={user._id} className="hover:bg-[#0f0f0f] transition-colors">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-white">{user.firstName}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-400">{user.email}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span
+                          className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                            user.role === 'admin'
+                              ? 'bg-purple-500 bg-opacity-20 text-purple-400'
+                              : user.role === 'creator'
+                              ? 'bg-yellow-500 bg-opacity-20 text-yellow-400'
+                              : 'bg-green-500 bg-opacity-20 text-green-400'
+                          }`}
+                        >
+                          {user.role}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-400">{formatDate(user.createdAt)}</div>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-6 py-4 text-center text-gray-400">
+                      No users found
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AdminDashboard


### PR DESCRIPTION
- Add adminMiddleware for role-based access control
- Create GET /api/v1/admin/stats endpoint for admin statistics
- Implement getAdminStats service to count users by role
- Add admin dashboard UI with user statistics cards
- Display total users, admins, regular users, and creators
- Show recent 10 registered users in table format
- Add proper error handling and authentication checks
- Update routes to include admin dashboard path